### PR TITLE
fix stackname base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-STACKNAME_BASE=pagerduty-oncall-slack-topic
+STACKNAME_BASE=pagerduty-slack-lambda-topic
 # if REGION is changed, use table in https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/ to update ChatTopicFunction lambda layer value
 REGION="us-east-2"
 # Bucket in REGION that is used for deployment (`pd-oncall-chat-topic` is already used)


### PR DESCRIPTION
Fixing a small oversight from #1

In order to deploy this yesterday I had actually updated the `STACKNAME_BASE` (mostly because of a small S3 bucket snafu). However, when I committed my changes I omitted this detail.
