### PR TITLE
turn off debug logs & tag resources

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -71,6 +71,12 @@ Resources:
   ConfigTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
+      Tags:
+        env: "production"
+        service: "pagerduty-slack-oncall"
+        version: !Ref md5
+        sofar:team: "platform"
+        sofar:cost-category: "opex"
       AttributeDefinitions:
         - AttributeName: "schedule"
           AttributeType: "S"
@@ -87,6 +93,12 @@ Resources:
   ChatTopicFunction:
     Type: AWS::Serverless::Function
     Properties:
+      Tags:
+        env: "production"
+        service: "pagerduty-slack-oncall"
+        version: !Ref md5
+        sofar:team: "platform"
+        sofar:cost-category: "opex"
       Handler: main.handler
       Runtime: python3.8
       Timeout: 120

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -16,7 +16,7 @@ sema = threading.Semaphore(value=maxthreads)
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.ERROR)
 
 # Fetch the PD API token from PD_API_KEY_NAME key in SSM
 PD_API_KEY = boto3.client('ssm').get_parameters(


### PR DESCRIPTION
Costs are minimal for both logging & running these resources, but it's still a good idea to keep these things organized and tidy.
